### PR TITLE
Update/content model

### DIFF
--- a/components/about/About.tsx
+++ b/components/about/About.tsx
@@ -4,7 +4,7 @@ import { Document } from "@contentful/rich-text-types";
 import { Asset } from "contentful";
 
 type Props = {
-    text: Document;
+    text?: Document;
     photo: Asset;
 };
 
@@ -24,7 +24,7 @@ export const About: React.FC<Props> = ({ text, photo }) => {
                     />
                 </div>
                 <div className="w-full body-text">
-                    {documentToReactComponents(text)}
+                    {text && documentToReactComponents(text)}
                 </div>
             </div>
         </section>

--- a/components/about/About.tsx
+++ b/components/about/About.tsx
@@ -1,21 +1,21 @@
 import Image from "next/image";
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
-import { IAbout } from "../../@types/generated/contentful";
+import { Document } from "@contentful/rich-text-types";
+import { Asset } from "contentful";
 
 type Props = {
-    section: IAbout;
+    text: Document;
+    photo: Asset;
 };
 
-export const About: React.FC<Props> = ({ section }) => {
-    const { body, profile } = section.fields;
-
+export const About: React.FC<Props> = ({ text, photo }) => {
     return (
         <section className="section-container" id="About">
             <h2 className="section-header">About</h2>
             <div className="w-full grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div className="flex justify-center max-h-96">
                     <Image
-                        src={`https:${profile?.fields.file.url}`}
+                        src={`https:${photo.fields.file.url}`}
                         width={300}
                         height={300}
                         objectFit="cover"
@@ -24,7 +24,7 @@ export const About: React.FC<Props> = ({ section }) => {
                     />
                 </div>
                 <div className="w-full body-text">
-                    {body && documentToReactComponents(body)}
+                    {documentToReactComponents(text)}
                 </div>
             </div>
         </section>

--- a/components/experience/Experience.tsx
+++ b/components/experience/Experience.tsx
@@ -1,22 +1,29 @@
-import { IExperience } from "../../@types/generated/contentful";
+import { Document } from "@contentful/rich-text-types";
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
 import { SkillList } from "../skillList/SkillList";
 
 type Props = {
-    section: IExperience;
+    text?: Document;
+    languages?: string[];
+    frameworks?: string[];
+    databases?: string[];
+    tools?: string[];
 };
 
-export const Experience: React.FC<Props> = ({ section }) => {
-    const { body, languages, frameworks, databases, tools } = section.fields;
-
-    console.log("languages: " + languages);
+export const Experience: React.FC<Props> = ({
+    text,
+    languages,
+    frameworks,
+    databases,
+    tools,
+}) => {
     return (
         <section className="section-container" id="Experience">
             <h2 className="section-header">Experience</h2>
             <div className="w-full grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                     <div className="w-full body-text">
-                        {body && documentToReactComponents(body)}
+                        {text && documentToReactComponents(text)}
                     </div>
                     <button className="solid-button mt-4">View Resume</button>
                 </div>

--- a/components/hero/Hero.tsx
+++ b/components/hero/Hero.tsx
@@ -1,22 +1,16 @@
-import { IHero } from "../../@types/generated/contentful";
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
+import { Document } from "@contentful/rich-text-types";
 
 type Props = {
-    section: IHero;
+    text: Document;
 };
 
-export const Hero: React.FC<Props> = ({ section }) => {
-    const { greeting, name, summary } = section.fields;
+export const Hero: React.FC<Props> = ({ text }) => {
     return (
         <section className="section-container">
-            <p className="text-2xl font-medium max-w-2xl px-8">
-                <span>{greeting}</span>
-                <br />
-                <span className="text-5xl font-bold highlight-text">
-                    {name}
-                </span>
-                <br />
-                <span>{summary}</span>
-            </p>
+            <div className="hero-text">
+                {text && documentToReactComponents(text)}
+            </div>
         </section>
     );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,6 +13,8 @@ import {
     IAbout,
     IExperience,
     IHero,
+    IHomepage,
+    IHomepageFields,
     IPageFields,
 } from "../@types/generated/contentful";
 
@@ -32,19 +34,21 @@ export const getStaticProps = async () => {
         space: space,
     });
 
-    // retrieve content by type
-    const response = await client.getEntries({ content_type: "page" });
-    const parsedResponse: EntryCollection<IPageFields> =
-        await client.parseEntries(response);
+    // retrieve homepage content by ID
+    const response: Entry<IHomepageFields> = await client.getEntry(
+        "LBrW2sfLs2xkMbx4o2jJU"
+    );
+
+    console.log(response.fields);
     return {
         props: {
-            sections: parsedResponse.items[0].fields.sections,
+            fields: response.fields,
         },
         revalidate: 1,
     };
 };
 
-const Home: NextPage<IPageFields> = ({ sections }) => {
+const Home: NextPage<IHomepage> = ({ fields }) => {
     // links to components on home page; won't load generated pages
     // each requires a unique child component, so declared statically
     const homepageLinks: string[] = [
@@ -54,6 +58,7 @@ const Home: NextPage<IPageFields> = ({ sections }) => {
         "Contact",
     ];
 
+    /*
     const heroSection = sections?.filter(
         (e): e is IHero => e.sys.contentType.sys.id === "hero"
     )[0];
@@ -65,24 +70,7 @@ const Home: NextPage<IPageFields> = ({ sections }) => {
     const experienceSection = sections?.filter(
         (e): e is IExperience => e.sys.contentType.sys.id === "experience"
     )[0];
-
-    const projects = [
-        {
-            bullets: ["testing", "data"],
-            title: "A",
-            technologies: ["html", "react", "vue"],
-        },
-        {
-            bullets: ["testing", "data"],
-            title: "B",
-            technologies: ["html", "react", "vue"],
-        },
-        {
-            bullets: ["testing", "data"],
-            title: "C",
-            technologies: ["html", "react", "vue"],
-        },
-    ];
+*/
     const footerLinks = [
         { icon: "github", url: "https://github.com" },
         { icon: "linkedin", url: "https://linkedin.com" },
@@ -103,12 +91,14 @@ const Home: NextPage<IPageFields> = ({ sections }) => {
             <Navbar homepageLinks={homepageLinks} />
 
             <main>
-                {heroSection && <Hero section={heroSection} />}
+                <Hero text={fields?.hero} />
+                {/* 
                 {aboutSection && <About section={aboutSection} />}
                 {experienceSection && (
                     <Experience section={experienceSection} />
                 )}
-                {projects && <Projects projects={projects} />}
+                <Projects projects={fields?.projects} />
+                */}
                 <Contact />
             </main>
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -92,8 +92,8 @@ const Home: NextPage<IHomepage> = ({ fields }) => {
 
             <main>
                 <Hero text={fields?.hero} />
+                <About text={fields?.about} photo={fields?.headshot} />}
                 {/* 
-                {aboutSection && <About section={aboutSection} />}
                 {experienceSection && (
                     <Experience section={experienceSection} />
                 )}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import { createClient, Entry, EntryCollection } from "contentful";
+import { createClient, Entry } from "contentful";
 import type { NextPage } from "next";
 import Head from "next/head";
 
@@ -9,14 +9,7 @@ import { Experience } from "../components/experience/Experience";
 import { Projects } from "../components/projects/Projects";
 import { Contact } from "../components/contact/Contact";
 import { Footer } from "../components/footer/Footer";
-import {
-    IAbout,
-    IExperience,
-    IHero,
-    IHomepage,
-    IHomepageFields,
-    IPageFields,
-} from "../@types/generated/contentful";
+import { IHomepage, IHomepageFields } from "../@types/generated/contentful";
 
 export const getStaticProps = async () => {
     const token = process.env.CONTENTFUL_ACCESS_TOKEN;
@@ -58,24 +51,23 @@ const Home: NextPage<IHomepage> = ({ fields }) => {
         "Contact",
     ];
 
-    /*
-    const heroSection = sections?.filter(
-        (e): e is IHero => e.sys.contentType.sys.id === "hero"
-    )[0];
+    const {
+        hero,
+        headshot,
+        about,
+        experience,
+        languages,
+        frameworks,
+        databases,
+        tools,
+    } = fields;
 
-    const aboutSection = sections?.filter(
-        (e): e is IAbout => e.sys.contentType.sys.id === "about"
-    )[0];
-
-    const experienceSection = sections?.filter(
-        (e): e is IExperience => e.sys.contentType.sys.id === "experience"
-    )[0];
-*/
     const footerLinks = [
         { icon: "github", url: "https://github.com" },
         { icon: "linkedin", url: "https://linkedin.com" },
         { icon: "email", url: "mailto:test@example.com" },
     ];
+
     return (
         <div className="dark:bg-slate-900">
             <Head>
@@ -91,12 +83,16 @@ const Home: NextPage<IHomepage> = ({ fields }) => {
             <Navbar homepageLinks={homepageLinks} />
 
             <main>
-                <Hero text={fields?.hero} />
-                <About text={fields?.about} photo={fields?.headshot} />}
+                <Hero text={hero} />
+                <About text={about} photo={headshot} />
+                <Experience
+                    text={experience}
+                    languages={languages}
+                    frameworks={frameworks}
+                    databases={databases}
+                    tools={tools}
+                />
                 {/* 
-                {experienceSection && (
-                    <Experience section={experienceSection} />
-                )}
                 <Projects projects={fields?.projects} />
                 */}
                 <Contact />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -24,6 +24,14 @@ h3 {
     font-family: "Lora", serif;
 }
 
+.hero-text p {
+    @apply text-xl font-medium max-w-2xl px-8 my-2;
+}
+
+.hero-text p b {
+    @apply text-4xl;
+}
+
 .body-text p {
     @apply my-2;
 }


### PR DESCRIPTION
Converts components to accept a new content model for the homepage's fields. Old model contained sections as their own content type, which was proving to be a bit excessive (no need for a whole About type when there's just one About section). Also reduces linked content, which presents issues when working with the Contentful SDK.

Example:

Rather than:
Page -> Project Section -> [Project, Project, Project]

We'll have:
Page -> [Project, Project, Project]

Also improves readability for component props quite a bit, which will help keep things smooth in the long run.