### PR TITLE
Persistent Layout

### DIFF
--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -1,19 +1,22 @@
 import { useTheme } from "next-themes";
-import { ISocialLink } from "../../@types/generated/contentful";
-
 import { Icon } from "../icon/Icon";
 
-type Props = {
-    links?: ISocialLink[];
-};
-
-export const Footer: React.FC<Props> = ({ links }) => {
+export const Footer: React.FC = () => {
     const { theme, setTheme } = useTheme();
+
+    const links = [
+        { title: "GitHub", url: "https://github.com/bbradforddesign" },
+        {
+            title: "LinkedIn",
+            url: "https://www.linkedin.com/in/blake-bradford/",
+        },
+        { title: "Email", url: "mailto:bbradforddesign@gmail.com" },
+    ];
 
     const renderSocialLinks =
         links &&
         links.map((e) => {
-            const { title, url } = e.fields;
+            const { title, url } = e;
 
             return (
                 <li key={title} className="w-min">

--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -1,9 +1,6 @@
-import { useTheme } from "next-themes";
 import { Icon } from "../icon/Icon";
 
 export const Footer: React.FC = () => {
-    const { theme, setTheme } = useTheme();
-
     const links = [
         { title: "GitHub", url: "https://github.com/bbradforddesign" },
         {
@@ -33,15 +30,8 @@ export const Footer: React.FC = () => {
         });
 
     return (
-        <footer className="w-full p-4 bg-white dark:bg-slate-900 opacity-95 sticky bottom-0 flex justify-between">
+        <footer className="w-full p-4 bg-white dark:bg-slate-900 flex justify-between">
             <ul className="flex gap-4">{renderSocialLinks}</ul>
-            <button
-                onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-                name="Dark mode toggle"
-                aria-label="Dark mode toggle"
-            >
-                <Icon icon="Lightbulb" />
-            </button>
         </footer>
     );
 };

--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -33,7 +33,7 @@ export const Footer: React.FC = () => {
         });
 
     return (
-        <footer className="w-full p-4 bg-white dark:bg-slate-900 sticky bottom-0 flex justify-between">
+        <footer className="w-full p-4 bg-white dark:bg-slate-900 opacity-95 sticky bottom-0 flex justify-between">
             <ul className="flex gap-4">{renderSocialLinks}</ul>
             <button
                 onClick={() => setTheme(theme === "dark" ? "light" : "dark")}

--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -33,7 +33,7 @@ export const Footer: React.FC = () => {
         });
 
     return (
-        <footer className="w-full p-4 opacity-95 backdrop-blur-lg bg-white dark:bg-slate-900 sticky bottom-0 flex justify-between">
+        <footer className="w-full p-4 bg-white dark:bg-slate-900 sticky bottom-0 flex justify-between">
             <ul className="flex gap-4">{renderSocialLinks}</ul>
             <button
                 onClick={() => setTheme(theme === "dark" ? "light" : "dark")}

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -8,12 +8,12 @@ type Props = {
 
 export const Layout: React.FC<Props> = ({ children }) => {
     return (
-        <>
+        <ThemeProvider attribute="class">
             <header className="sticky z-10 absolute top-0 -mb-12">
                 <Navbar />
             </header>
             <main className="dark:bg-slate-900">{children}</main>
             <Footer />
-        </>
+        </ThemeProvider>
     );
 };

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -1,0 +1,19 @@
+import { Navbar } from "../navbar/Navbar";
+import { Footer } from "../footer/Footer";
+import { ThemeProvider } from "next-themes";
+
+type Props = {
+    children: React.ReactNode;
+};
+
+export const Layout: React.FC<Props> = ({ children }) => {
+    return (
+        <ThemeProvider attribute="class">
+            <header className="sticky z-10 absolute top-0 -mb-12">
+                <Navbar />
+            </header>
+            <main className="dark:bg-slate-900">{children}</main>
+            <Footer />
+        </ThemeProvider>
+    );
+};

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { Navbar } from "../navbar/Navbar";
 import { Footer } from "../footer/Footer";
 import { ThemeProvider } from "next-themes";
+import { ThemeToggle } from "../themeToggle/ThemeToggle";
 
 type Props = {
     children: React.ReactNode;
@@ -13,6 +14,7 @@ export const Layout: React.FC<Props> = ({ children }) => {
                 <Navbar />
             </header>
             <main className="dark:bg-slate-900">{children}</main>
+            <ThemeToggle />
             <Footer />
         </ThemeProvider>
     );

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -8,12 +8,12 @@ type Props = {
 
 export const Layout: React.FC<Props> = ({ children }) => {
     return (
-        <ThemeProvider attribute="class">
+        <>
             <header className="sticky z-10 absolute top-0 -mb-12">
                 <Navbar />
             </header>
             <main className="dark:bg-slate-900">{children}</main>
             <Footer />
-        </ThemeProvider>
+        </>
     );
 };

--- a/components/navbar/Navbar.stories.tsx
+++ b/components/navbar/Navbar.stories.tsx
@@ -15,6 +15,4 @@ const Template: ComponentStory<typeof Navbar> = (args) => (
 );
 
 export const Default = Template.bind({});
-Default.args = {
-    homepageLinks: ["About", "Experience", "Projects", "Contact"],
-};
+Default.args = {};

--- a/components/navbar/Navbar.tsx
+++ b/components/navbar/Navbar.tsx
@@ -16,7 +16,7 @@ export const Navbar: React.FC = () => {
     // render links to homepage sections; not generated pages
     const renderHomepageLinks = homepageLinks.map((e) => (
         <li className="ml-12 my-2 w-fit lg:my-0 lg:ml-4" key={e}>
-            <Link href={`/#${e}`}>
+            <Link shallow={true} href={`/#${e}`}>
                 <a className="nav-link">{e}</a>
             </Link>
         </li>

--- a/components/navbar/Navbar.tsx
+++ b/components/navbar/Navbar.tsx
@@ -27,7 +27,7 @@ export const Navbar: React.FC = () => {
     ));
 
     return (
-        <nav className="flex flex-col justify-between items-start p-4 w-full opacity-95 backdrop-blur-lg bg-white dark:bg-slate-900 border-b-2 lg:flex-row lg:items-center">
+        <nav className="flex flex-col justify-between items-start p-4 w-full bg-white dark:bg-slate-900 border-b-2 lg:flex-row lg:items-center">
             <div className="flex flex-row justify-between items-center w-full">
                 <h1 className="font-bold text-xl">
                     <Link href={{ pathname: "/", hash: "" }}>

--- a/components/navbar/Navbar.tsx
+++ b/components/navbar/Navbar.tsx
@@ -16,14 +16,14 @@ export const Navbar: React.FC = () => {
     // render links to homepage sections; not generated pages
     const renderHomepageLinks = homepageLinks.map((e) => (
         <li className="ml-12 my-2 w-fit lg:my-0 lg:ml-4" key={e}>
-            <Link shallow={true} scroll={false} href={`#${e}`}>
+            <Link shallow={true} href={`#${e}`}>
                 <a className="nav-link">{e}</a>
             </Link>
         </li>
     ));
 
     return (
-        <nav className="flex flex-col justify-between items-start p-4 w-full bg-white dark:bg-slate-900 border-b-2 lg:flex-row lg:items-center">
+        <nav className="flex flex-col justify-between items-start p-4 w-full opacity-95 bg-white dark:bg-slate-900 border-b-2 lg:flex-row lg:items-center">
             <div className="flex flex-row justify-between items-center w-full">
                 <Link href="#">
                     <a>

--- a/components/navbar/Navbar.tsx
+++ b/components/navbar/Navbar.tsx
@@ -1,11 +1,8 @@
 import { useState } from "react";
-import { useRouter } from "next/router";
 import Link from "next/link";
 
 export const Navbar: React.FC = () => {
     const [openNav, setOpenNav] = useState<boolean>(false);
-
-    const router = useRouter();
 
     // each link name keyword is tied to a specific component; constant is pre-defined for simplicity
     // links point to sections on homepage, not separate pages
@@ -20,13 +17,7 @@ export const Navbar: React.FC = () => {
     const renderHomepageLinks = homepageLinks.map((e) => (
         <li className="ml-12 my-2 w-fit lg:my-0 lg:ml-4" key={e}>
             <Link shallow={true} href={`#${e}`}>
-                <a
-                    className={`nav-link ${
-                        router.asPath.slice(2) === e && "active-link"
-                    }`}
-                >
-                    {e}
-                </a>
+                <a className="nav-link">{e}</a>
             </Link>
         </li>
     ));

--- a/components/navbar/Navbar.tsx
+++ b/components/navbar/Navbar.tsx
@@ -15,9 +15,13 @@ export const Navbar: React.FC = () => {
 
     // render links to homepage sections; not generated pages
     const renderHomepageLinks = homepageLinks.map((e) => (
-        <li className="ml-12 my-2 w-fit lg:my-0 lg:ml-4" key={e}>
-            <Link shallow={true} scroll={false} href={`#${e}`}>
-                <a className="nav-link">{e}</a>
+        <li className="nav-link ml-12 my-2 w-fit lg:my-0 lg:ml-4" key={e}>
+            <Link
+                shallow={true}
+                scroll={false}
+                href={{ pathname: "/", hash: e }}
+            >
+                {e}
             </Link>
         </li>
     ));
@@ -25,11 +29,11 @@ export const Navbar: React.FC = () => {
     return (
         <nav className="flex flex-col justify-between items-start p-4 w-full opacity-95 backdrop-blur-lg bg-white dark:bg-slate-900 border-b-2 lg:flex-row lg:items-center">
             <div className="flex flex-row justify-between items-center w-full">
-                <Link href="#">
-                    <a>
-                        <h1 className="font-bold text-xl">bbradforddesign</h1>
-                    </a>
-                </Link>
+                <h1 className="font-bold text-xl">
+                    <Link href={{ pathname: "/", hash: "" }}>
+                        bbradforddesign
+                    </Link>
+                </h1>
                 <button
                     className="lg:hidden relative h-6 w-8"
                     aria-label="navigation toggle"

--- a/components/navbar/Navbar.tsx
+++ b/components/navbar/Navbar.tsx
@@ -1,12 +1,17 @@
 import { useState } from "react";
 import Link from "next/link";
 
-type Props = {
-    homepageLinks: string[];
-};
-
-export const Navbar: React.FC<Props> = ({ homepageLinks }) => {
+export const Navbar: React.FC = () => {
     const [openNav, setOpenNav] = useState<boolean>(false);
+
+    // each link name keyword is tied to a specific component; constant is pre-defined for simplicity
+    // links point to sections on homepage, not separate pages
+    const homepageLinks: string[] = [
+        "About",
+        "Experience",
+        "Projects",
+        "Contact",
+    ];
 
     // render links to homepage sections; not generated pages
     const renderHomepageLinks = homepageLinks.map((e) => (
@@ -18,7 +23,7 @@ export const Navbar: React.FC<Props> = ({ homepageLinks }) => {
     ));
 
     return (
-        <nav className="flex flex-col justify-between items-start p-4 w-full sticky top-0 -mb-12 z-10 opacity-95 backdrop-blur-lg bg-white dark:bg-slate-900 border-b-2 lg:flex-row lg:items-center">
+        <nav className="flex flex-col justify-between items-start p-4 w-full opacity-95 backdrop-blur-lg bg-white dark:bg-slate-900 border-b-2 lg:flex-row lg:items-center">
             <div className="flex flex-row justify-between items-center w-full">
                 <Link href="/#">
                     <a>

--- a/components/navbar/Navbar.tsx
+++ b/components/navbar/Navbar.tsx
@@ -15,13 +15,9 @@ export const Navbar: React.FC = () => {
 
     // render links to homepage sections; not generated pages
     const renderHomepageLinks = homepageLinks.map((e) => (
-        <li className="nav-link ml-12 my-2 w-fit lg:my-0 lg:ml-4" key={e}>
-            <Link
-                shallow={true}
-                scroll={false}
-                href={{ pathname: "/", hash: e }}
-            >
-                {e}
+        <li className="ml-12 my-2 w-fit lg:my-0 lg:ml-4" key={e}>
+            <Link shallow={true} scroll={false} href={`#${e}`}>
+                <a className="nav-link">{e}</a>
             </Link>
         </li>
     ));
@@ -29,11 +25,11 @@ export const Navbar: React.FC = () => {
     return (
         <nav className="flex flex-col justify-between items-start p-4 w-full bg-white dark:bg-slate-900 border-b-2 lg:flex-row lg:items-center">
             <div className="flex flex-row justify-between items-center w-full">
-                <h1 className="font-bold text-xl">
-                    <Link href={{ pathname: "/", hash: "" }}>
-                        bbradforddesign
-                    </Link>
-                </h1>
+                <Link href="#">
+                    <a>
+                        <h1 className="font-bold text-xl">bbradforddesign</h1>
+                    </a>
+                </Link>
                 <button
                     className="lg:hidden relative h-6 w-8"
                     aria-label="navigation toggle"

--- a/components/navbar/Navbar.tsx
+++ b/components/navbar/Navbar.tsx
@@ -16,7 +16,7 @@ export const Navbar: React.FC = () => {
     // render links to homepage sections; not generated pages
     const renderHomepageLinks = homepageLinks.map((e) => (
         <li className="ml-12 my-2 w-fit lg:my-0 lg:ml-4" key={e}>
-            <Link shallow={true} href={`/#${e}`}>
+            <Link shallow={true} scroll={false} href={`#${e}`}>
                 <a className="nav-link">{e}</a>
             </Link>
         </li>
@@ -25,7 +25,7 @@ export const Navbar: React.FC = () => {
     return (
         <nav className="flex flex-col justify-between items-start p-4 w-full opacity-95 backdrop-blur-lg bg-white dark:bg-slate-900 border-b-2 lg:flex-row lg:items-center">
             <div className="flex flex-row justify-between items-center w-full">
-                <Link href="/#">
+                <Link href="#">
                     <a>
                         <h1 className="font-bold text-xl">bbradforddesign</h1>
                     </a>

--- a/components/navbar/Navbar.tsx
+++ b/components/navbar/Navbar.tsx
@@ -1,8 +1,11 @@
 import { useState } from "react";
+import { useRouter } from "next/router";
 import Link from "next/link";
 
 export const Navbar: React.FC = () => {
     const [openNav, setOpenNav] = useState<boolean>(false);
+
+    const router = useRouter();
 
     // each link name keyword is tied to a specific component; constant is pre-defined for simplicity
     // links point to sections on homepage, not separate pages
@@ -17,7 +20,13 @@ export const Navbar: React.FC = () => {
     const renderHomepageLinks = homepageLinks.map((e) => (
         <li className="ml-12 my-2 w-fit lg:my-0 lg:ml-4" key={e}>
             <Link shallow={true} href={`#${e}`}>
-                <a className="nav-link">{e}</a>
+                <a
+                    className={`nav-link ${
+                        router.asPath.slice(2) === e && "active-link"
+                    }`}
+                >
+                    {e}
+                </a>
             </Link>
         </li>
     ));

--- a/components/themeToggle/ThemeToggle.tsx
+++ b/components/themeToggle/ThemeToggle.tsx
@@ -1,0 +1,18 @@
+import { useTheme } from "next-themes";
+import { Icon } from "../icon/Icon";
+
+export const ThemeToggle = () => {
+    const { theme, setTheme } = useTheme();
+    return (
+        <button
+            onClick={() => {
+                setTheme(theme === "dark" ? "light" : "dark");
+            }}
+            name="Dark mode toggle"
+            aria-label="Dark mode toggle"
+            className="fixed right-4 bottom-4 bg-white dark:bg-slate-800 rounded-full p-2 shadow-md"
+        >
+            <Icon icon="Lightbulb" />
+        </button>
+    );
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,14 @@
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
 
+import { Layout } from "../components/layout/Layout";
+
 function MyApp({ Component, pageProps }: AppProps) {
-    return <Component {...pageProps} />;
+    return (
+        <Layout>
+            <Component {...pageProps} />
+        </Layout>
+    );
 }
 
 export default MyApp;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,25 +1,8 @@
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
-import { ThemeProvider } from "next-themes";
-
-import { Navbar } from "../components/navbar/Navbar";
 
 function MyApp({ Component, pageProps }: AppProps) {
-    // each link name keyword is tied to a specific component; constant is pre-defined for simplicity
-    // links point to sections on homepage, not separate pages
-    const homepageLinks: string[] = [
-        "About",
-        "Experience",
-        "Projects",
-        "Contact",
-    ];
-
-    return (
-        <ThemeProvider attribute="class">
-            <Navbar homepageLinks={homepageLinks} />
-            <Component {...pageProps} />
-        </ThemeProvider>
-    );
+    return <Component {...pageProps} />;
 }
 
 export default MyApp;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,6 @@ import { createClient, Entry } from "contentful";
 import type { NextPage } from "next";
 import Head from "next/head";
 
-import { Layout } from "../components/layout/Layout";
 import { Hero } from "../components/hero/Hero";
 import { About } from "../components/about/About";
 import { Experience } from "../components/experience/Experience";
@@ -55,7 +54,7 @@ const Home: NextPage<IHomepage> = ({ fields }) => {
     } = fields;
 
     return (
-        <Layout>
+        <>
             <Head>
                 <title>bbradforddesign</title>
                 <meta name="description" content="Blake Bradford" />
@@ -72,7 +71,7 @@ const Home: NextPage<IHomepage> = ({ fields }) => {
             />
             <Projects projects={projects} />
             <Contact contact={contact} />
-        </Layout>
+        </>
     );
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,12 +2,12 @@ import { createClient, Entry } from "contentful";
 import type { NextPage } from "next";
 import Head from "next/head";
 
+import { Layout } from "../components/layout/Layout";
 import { Hero } from "../components/hero/Hero";
 import { About } from "../components/about/About";
 import { Experience } from "../components/experience/Experience";
 import { Projects } from "../components/projects/Projects";
 import { Contact } from "../components/contact/Contact";
-import { Footer } from "../components/footer/Footer";
 import { IHomepage, IHomepageFields } from "../@types/generated/contentful";
 
 export const getStaticProps = async () => {
@@ -51,32 +51,28 @@ const Home: NextPage<IHomepage> = ({ fields }) => {
         tools,
         projects,
         contact,
-        socialLinks,
         resume,
     } = fields;
 
     return (
-        <div className="dark:bg-slate-900">
+        <Layout>
             <Head>
                 <title>bbradforddesign</title>
                 <meta name="description" content="Blake Bradford" />
             </Head>
-            <main>
-                <Hero text={hero} />
-                <About text={about} photo={headshot} />
-                <Experience
-                    text={experience}
-                    languages={languages}
-                    frameworks={frameworks}
-                    databases={databases}
-                    tools={tools}
-                    resume={resume}
-                />
-                <Projects projects={projects} />
-                <Contact contact={contact} />
-            </main>
-            <Footer links={socialLinks} />
-        </div>
+            <Hero text={hero} />
+            <About text={about} photo={headshot} />
+            <Experience
+                text={experience}
+                languages={languages}
+                frameworks={frameworks}
+                databases={databases}
+                tools={tools}
+                resume={resume}
+            />
+            <Projects projects={projects} />
+            <Contact contact={contact} />
+        </Layout>
     );
 };
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,6 +8,7 @@ body {
     margin: 0;
     font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
         Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+    scroll-behavior: smooth;
 }
 
 a {
@@ -97,7 +98,7 @@ h4 {
 
 .section-container {
     min-height: calc(100vh - theme("spacing.80"));
-    @apply flex flex-col justify-center items-center  w-full max-w-6xl h-auto my-4 mx-auto p-12;
+    @apply flex flex-col justify-center items-center w-full max-w-6xl h-auto mx-auto p-12;
 }
 
 .section-header {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -64,7 +64,8 @@ h4 {
     @apply relative font-semibold text-lg;
 }
 
-.nav-link:hover {
+.nav-link:hover,
+.nav-link:focus {
     @apply active-link;
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -61,7 +61,15 @@ h4 {
 }
 
 .nav-link {
-    @apply relative font-semibold text-lg hover:text-blue-600 dark:hover:text-yellow-300;
+    @apply relative font-semibold text-lg;
+}
+
+.nav-link:hover {
+    @apply active-link;
+}
+
+.active-link {
+    @apply text-blue-600 dark:text-yellow-300;
 }
 
 .nav-link::after {
@@ -69,7 +77,7 @@ h4 {
     content: "";
 }
 
-.nav-link:hover::after {
+.active-link:hover::after {
     @apply scale-x-100 bg-blue-600 dark:bg-yellow-300;
     content: "";
 }


### PR DESCRIPTION
Move persistent components into a Layout component to prevent extra rerenders. Also moved navbar and footer links out of props, and into the components themselves, since they're static values.